### PR TITLE
fix ex0720.go; メソッドの指定ミスによるコンパイル不可を修正

### DIFF
--- a/example/ch07/ex0720.go
+++ b/example/ch07/ex0720.go
@@ -96,7 +96,7 @@ type Controller struct {
     logic Logic
 }
 
-func (c Controller) SayHello(w http.ResponseWriter, r *http.Request) {
+func (c Controller) HandleGreeting(w http.ResponseWriter, r *http.Request) {
     c.l.Log("SayHello内: ")
     userID := r.URL.Query().Get("user_id")
     message, err := c.logic.SayHello(userID)
@@ -120,7 +120,7 @@ func main() {
     ds := NewSimpleDataStore()
     logic := NewSimpleLogic(l, ds)
     c := NewController(l, logic)
-    http.HandleFunc("/hello", c.SayHello)
+    http.HandleFunc("/hello", c.HandleGreeting)
     http.ListenAndServe(":8080", nil)
 }
 


### PR DESCRIPTION
書籍を参考に学習させていただいております。 7章のサンプルコード（ex0720.go）を実行しようとしたところ、コンパイルエラーが発生しました。

## 修正内容
http.HandleFuncの引数に指定されているメソッド名がc.SayHelloになっていますが、Controller構造体にそのメソッドは定義されておらず、シグネチャも合わないため、正しくはc.HandleGreetingであると思われます。 そのため、該当箇所を修正いたしました。

## 動作確認
手元の環境で修正後にgo runを行い、/helloへのアクセスが正常に動作することを確認しています。

<img width="520" height="169" alt="image" src="https://github.com/user-attachments/assets/283f1b19-5715-4520-943e-ce1430146588" />

マージのご検討をいただけますと幸いです。よろしくお願いいたします。